### PR TITLE
Link `Date` and `DateTime` to schema.org definitions

### DIFF
--- a/draft/index.html
+++ b/draft/index.html
@@ -492,8 +492,8 @@ Erstellungsdatum der Ressource. MUSS einer Datumsangabe gemäß [[!ISO8601]] ent
 <dt>Pflichtfeld</dt>
 <dd>nein</dd>
 <dt>Typ</dt>
-<dd>`Date`</dd>
-<dd>`DateTime`</dd>
+<dd><a href="https://schema.org/Date">`Date`</a></dd>
+<dd><a href="https://schema.org/DateTime">`DateTime`</a></dd>
 <dt>Werte</dt>
 <dd>[[!ISO8601]]</dd>
 <dt>Validierung</dt>
@@ -513,8 +513,8 @@ Publikationssdatum der Ressource. MUSS einer Datumsangabe gemäß [[!ISO8601]] e
 <dt>Pflichtfeld</dt>
 <dd>nein</dd>
 <dt>Typ</dt>
-<dd>`Date`</dd>
-<dd>`DateTime`</dd>
+<dd><a href="https://schema.org/Date">`Date`</a></dd>
+<dd><a href="https://schema.org/DateTime">`DateTime`</a></dd>
 <dt>Werte</dt>
 <dd>[[!ISO8601]]</dd>
 <dt>Validierung</dt>

--- a/draft/index.html
+++ b/draft/index.html
@@ -486,7 +486,7 @@ Thumbnail der Ressource.
 
 ### <dfn>dateCreated</dfn>
 
-Erstellungsdatum der Ressource. MUSS einer Datumsangabe gemäß [[!ISO8601]] entsprechen.
+Erstellungsdatum der Ressource. MUSS ein String der Form `CCYY-MM-DD` für Datumsangaben oder ein String der Form `CCYY-MM-DDThh:mm:ss[Z|(+|-)hh:mm]` für Zeitangaben sein.
 
 <dl>
 <dt>Pflichtfeld</dt>
@@ -496,7 +496,7 @@ Erstellungsdatum der Ressource. MUSS einer Datumsangabe gemäß [[!ISO8601]] ent
 <dd>`DateTime`</dd>
 <dt>Werte</dt>
 <dd>`Date`: String der Form `CCYY-MM-DD` (siehe [[!ISO8601]])</dd>
-<dd>`DateTime`: String der Form `CCYY-MM-DDThh:mm:ss[Z|(+|-)hh:mm]` (siehe [[!ISO8601]])</dd>
+<dd>`DateTime`: String der Form `CCYY-MM-DDThh:mm:ss[Z|(+|-)hh:mm]` (siehe [[!ISO8601]], Kapitel 5.4)</dd>
 <dt>Validierung</dt>
 <dd><a href="https://w3id.org/kim/amb/draft/schemas/dateCreated.json">JSON Schema</a></dd>
 </dl>
@@ -508,7 +508,7 @@ Erstellungsdatum der Ressource. MUSS einer Datumsangabe gemäß [[!ISO8601]] ent
 
 ### <dfn>datePublished</dfn>
 
-Publikationssdatum der Ressource. MUSS einer Datumsangabe gemäß [[!ISO8601]] entsprechen.
+Publikationssdatum der Ressource. MUSS ein String der Form `CCYY-MM-DD` für Datumsangaben oder ein String der Form `CCYY-MM-DDThh:mm:ss[Z|(+|-)hh:mm]` für Zeitangaben sein.
 
 <dl>
 <dt>Pflichtfeld</dt>
@@ -518,7 +518,7 @@ Publikationssdatum der Ressource. MUSS einer Datumsangabe gemäß [[!ISO8601]] e
 <dd>`DateTime`</dd>
 <dt>Werte</dt>
 <dd>`Date`: String der Form `CCYY-MM-DD` (siehe [[!ISO8601]])</dd>
-<dd>`DateTime`: String der Form `CCYY-MM-DDThh:mm:ss[Z|(+|-)hh:mm]` (siehe [[!ISO8601]])</dd>
+<dd>`DateTime`: String der Form `CCYY-MM-DDThh:mm:ss[Z|(+|-)hh:mm]` (siehe [[!ISO8601]], Kapitel 5.4)</dd>
 <dt>Validierung</dt>
 <dd><a href="https://w3id.org/kim/amb/draft/schemas/datePublished.json">JSON Schema</a></dd>
 </dl>

--- a/draft/index.html
+++ b/draft/index.html
@@ -492,10 +492,11 @@ Erstellungsdatum der Ressource. MUSS einer Datumsangabe gemäß [[!ISO8601]] ent
 <dt>Pflichtfeld</dt>
 <dd>nein</dd>
 <dt>Typ</dt>
-<dd><a href="https://schema.org/Date">`Date`</a></dd>
-<dd><a href="https://schema.org/DateTime">`DateTime`</a></dd>
+<dd>`Date`</dd>
+<dd>`DateTime`</dd>
 <dt>Werte</dt>
-<dd>[[!ISO8601]]</dd>
+<dd>`Date`: String der Form `CCYY-MM-DD` (siehe [[!ISO8601]])</dd>
+<dd>`DateTime`: String der Form `CCYY-MM-DDThh:mm:ss[Z|(+|-)hh:mm]` (siehe [[!ISO8601]])</dd>
 <dt>Validierung</dt>
 <dd><a href="https://w3id.org/kim/amb/draft/schemas/dateCreated.json">JSON Schema</a></dd>
 </dl>
@@ -513,10 +514,11 @@ Publikationssdatum der Ressource. MUSS einer Datumsangabe gemäß [[!ISO8601]] e
 <dt>Pflichtfeld</dt>
 <dd>nein</dd>
 <dt>Typ</dt>
-<dd><a href="https://schema.org/Date">`Date`</a></dd>
-<dd><a href="https://schema.org/DateTime">`DateTime`</a></dd>
+<dd>`Date`</dd>
+<dd>`DateTime`</dd>
 <dt>Werte</dt>
-<dd>[[!ISO8601]]</dd>
+<dd>`Date`: String der Form `CCYY-MM-DD` (siehe [[!ISO8601]])</dd>
+<dd>`DateTime`: String der Form `CCYY-MM-DDThh:mm:ss[Z|(+|-)hh:mm]` (siehe [[!ISO8601]])</dd>
 <dt>Validierung</dt>
 <dd><a href="https://w3id.org/kim/amb/draft/schemas/datePublished.json">JSON Schema</a></dd>
 </dl>


### PR DESCRIPTION
Follow up of discussion https://github.com/dini-ag-kim/amb/issues/117: Linking the date types to the schema.org pages helps in making clear which strings are accepted here. Especially https://schema.org/DateTime is helpful since it includes a regex.