### PR TITLE
Add duration (#90)

### DIFF
--- a/draft/examples/invalid/wrongDuration.json
+++ b/draft/examples/invalid/wrongDuration.json
@@ -1,0 +1,48 @@
+{
+    "@context": [
+      "https://w3id.org/kim/amb/draft/context.jsonld",
+      {
+        "@language": "de"
+      }
+    ],
+    "type": [
+      "LearningResource",
+      "VideoObject"
+    ],
+    "name": "The road ahead for network freedom",
+    "inLanguage": [
+      "en"
+    ],
+    "id": "https://av.tib.eu/media/32641",
+    "learningResourceType": [
+      {
+        "id": "https://w3id.org/kim/hcrt/video",
+        "prefLabel": {
+          "de": "Video",
+          "en": "Video"
+        }
+      }
+    ],
+    "image": "https://av.tib.eu/thumbnail/32641",
+    "duration": "47m58s",
+    "encoding": [
+      {
+        "type": "MediaObject",
+        "encodingFormat": "video/mp4",
+        "sha256": "5daa33f7826285c1af76c7a2341707b5103e0208c7c425b71f00a72ff9beadde",
+        "bitrate": "1651",
+        "contentSize": "568000000",
+        "contentUrl": "https://tib.flowcenter.de/mfc/medialink/3/dea844a48268f9c1d10e340613eb0d0c87fcdc8e04b9980efa06743a026e99a979/_FOSDEM_2014__The_road_ahead_for_network_freedom_4vNMAOJDhhw_v1500a128.mp4"
+      },
+      {
+        "type": "MediaObject",
+        "encodingFormat": "video/mp4",
+        "sha256": "af96aba0790476495cfb5fa6d5612b91d8e404bb0d53aaf4b19bb8bd49843959",
+        "bitrate": "831",
+        "contentSize": "286000000",
+        "contentUrl": "https://tib.flowcenter.de/mfc/medialink/3/dececd3fadf9ab5d198c6c2fb886fadacfe208efc67b76c5f2503dab055bace61b/_FOSDEM_2014__The_road_ahead_for_network_freedom_4vNMAOJDhhw.mp4",
+        "embedUrl": "https://av.tib.eu/player/32641"
+      }
+    ]
+  }
+  

--- a/draft/examples/valid/videoWithEncodings.json
+++ b/draft/examples/valid/videoWithEncodings.json
@@ -24,6 +24,7 @@
     }
   ],
   "image": "https://av.tib.eu/thumbnail/32641",
+  "duration": "PT47M58S",
   "encoding": [
     {
       "type": "MediaObject",

--- a/draft/index.html
+++ b/draft/index.html
@@ -556,6 +556,23 @@ Publikationssdatum der Ressource. MUSS ein String der Form `CCYY-MM-DD` für Dat
 
 </section>
 
+<section data-dfn-for="duration">
+
+### <dfn>duration</dfn>
+
+Dauer der Wiedergabe einer Audio/Video-Ressource.
+
+<dl>
+<dt>Pflichtfeld</dt>
+<dd>nein</dd>
+<dt>Typ</dt>
+<dd>`string` der Form `PnYnMnDTnHnMnS` gemäß [[!ISO8601]] "Duration"-Format.</dd>
+<dt>Validierung</dt>
+<dd><a href="https://w3id.org/kim/amb/draft/schemas/duration.json">JSON Schema</a></dd>
+</dl>
+
+</section>
+
 <section data-dfn-for="inLanguage">
 
 ### <dfn>inLanguage</dfn>

--- a/draft/schemas/duration.json
+++ b/draft/schemas/duration.json
@@ -2,7 +2,7 @@
   "$id": "https://w3id.org/kim/amb/draft/schemas/duration.json",
   "$schema": "http://json-schema.org/draft-07/schema#",
   "title": "Duration",
-  "description": "The duration of the item (video, audio recording, etc.) in ISO 8601 date format.",
+  "description": "The duration of the item (video, audio recording, etc.) in ISO 8601 duration format.",
   "type": "string",
   "pattern": "^(-?)P(?=\\d|T\\d)(?:(\\d+)Y)?(?:(\\d+)M)?(?:(\\d+)([DW]))?(?:T(?:(\\d+)H)?(?:(\\d+)M)?(?:(\\d+(?:\\.\\d+)?)S)?)?$"
 }

--- a/draft/schemas/duration.json
+++ b/draft/schemas/duration.json
@@ -1,0 +1,8 @@
+{
+  "$id": "https://w3id.org/kim/amb/draft/schemas/duration.json",
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "Duration",
+  "description": "The duration of the item (video, audio recording, etc.) in ISO 8601 date format.",
+  "type": "string",
+  "pattern": "^(-?)P(?=\\d|T\\d)(?:(\\d+)Y)?(?:(\\d+)M)?(?:(\\d+)([DW]))?(?:T(?:(\\d+)H)?(?:(\\d+)M)?(?:(\\d+(?:\\.\\d+)?)S)?)?$"
+}

--- a/draft/schemas/duration.json
+++ b/draft/schemas/duration.json
@@ -2,7 +2,7 @@
   "$id": "https://w3id.org/kim/amb/draft/schemas/duration.json",
   "$schema": "http://json-schema.org/draft-07/schema#",
   "title": "Duration",
-  "description": "The duration of the item (video, audio recording, etc.) in ISO 8601 duration format.",
+  "description": "The duration of the item (video, audio recording, etc.) in ISO 8601 duration format: P[n]Y[n]M[n]DT[n]H[n]M[n]S",
   "type": "string",
   "pattern": "^(-?)P(?=\\d|T\\d)(?:(\\d+)Y)?(?:(\\d+)M)?(?:(\\d+)([DW]))?(?:T(?:(\\d+)H)?(?:(\\d+)M)?(?:(\\d+(?:\\.\\d+)?)S)?)?$"
 }

--- a/draft/schemas/schema.json
+++ b/draft/schemas/schema.json
@@ -52,6 +52,9 @@
     "datePublished": {
       "$ref": "https://w3id.org/kim/amb/draft/schemas/datePublished.json"
     },
+    "duration": {
+      "$ref": "https://w3id.org/kim/amb/draft/schemas/duration.json"
+    },
     "inLanguage": {
       "$ref": "https://w3id.org/kim/amb/draft/schemas/inLanguage.json"
     },


### PR DESCRIPTION
Einer von zwei PRs um #90 zu schließen.

Im JSON Schema habe ich `pattern` mit einer Regular Expression von https://rgxdb.com/r/MD2234J verwendet. Es gibt zwar auch `"format": "duration"`, das wird aber erst mit JSON Schema Draft 2019-09 aufwärts unterstützt und wirgeben gerade Draft 7 an.

Im Übrigen habe ich ein schlechtes Gefühl, dass die Spec so häufig (auch bei `dateCreated` und `dateModified`) ISO 8601 referenziert, das ja nur gegen Bezahlung gelesen werden kann. Deshalb habe ich mir ISO 8601 selbst nie angeschaut und die meisten Spec-Leser\*innen wird es auch so gehen. Wir sollten vielleicht mal in der Zukunft schauen, wie wir eine ISO-Referenz umgehen können.Siehe dazu auch [dieses Ticket bei JSON Schema](https://github.com/json-schema-org/json-schema-spec/issues/947), wo diskutiert wird, ob ISO referenziert werden soll mit dem Ergebnis es zu lassen, weil "it would create a bad user experience and was against the spirit of an open specification" ([Quelle](https://github.com/json-schema-org/json-schema-spec/issues/947#issuecomment-666515489)).