### PR TITLE
Improve description of caption and duration

### DIFF
--- a/draft/schemas/caption.json
+++ b/draft/schemas/caption.json
@@ -2,7 +2,7 @@
   "$id": "https://w3id.org/kim/amb/draft/schemas/caption.json",
   "$schema": "http://json-schema.org/draft-07/schema#",
   "title": "Caption",
-  "description": "The caption for a resource",
+  "description": "The caption/subtitle file for an audio/video resource",
   "type": "array",
   "items": {
     "type": "object",

--- a/draft/schemas/duration.json
+++ b/draft/schemas/duration.json
@@ -2,7 +2,7 @@
   "$id": "https://w3id.org/kim/amb/draft/schemas/duration.json",
   "$schema": "http://json-schema.org/draft-07/schema#",
   "title": "Duration",
-  "description": "The duration of the item (video, audio recording, etc.) in ISO 8601 duration format: P[n]Y[n]M[n]DT[n]H[n]M[n]S",
+  "description": "The duration of an audio/video resource (the time it takes to play the audio/video resource) in ISO 8601 duration format: P[n]Y[n]M[n]DT[n]H[n]M[n]S",
   "type": "string",
   "pattern": "^(-?)P(?=\\d|T\\d)(?:(\\d+)Y)?(?:(\\d+)M)?(?:(\\d+)([DW]))?(?:T(?:(\\d+)H)?(?:(\\d+)M)?(?:(\\d+(?:\\.\\d+)?)S)?)?$"
 }


### PR DESCRIPTION
Verdeutlichung der Beschreibung von `caption` und `duration` damit keine Missverständnisse aufkommen und die Felder nicht falsch benutzt werden.