### PR TITLE
add funder

### DIFF
--- a/draft/examples/invalid/funderInvalidType.json
+++ b/draft/examples/invalid/funderInvalidType.json
@@ -1,0 +1,78 @@
+{
+  "@context": [
+    "https://w3id.org/kim/amb/context.jsonld",
+    {
+      "@language": "de"
+    }
+  ],
+  "name": "Beispielressource",
+  "image": "https://example.org/oer/image.png",
+  "type": [
+    "LearningResource"
+  ],
+  "funder": [
+    {
+        "type": "Offer",
+        "id": "https://example.org/foerderprogramm",
+        "name": "Förderprogramm A"
+    }
+  ],
+  "creator": [
+    {
+      "honorificPrefix": "Dr.",
+      "name": "Hans Dampf",
+      "type": "Person",
+      "affiliation": {
+        "id": "http://www.wikidata.org/entity/Q54096",
+        "type": "Organization",
+        "name": "Universität Köln"
+      }
+    },
+    {
+      "id": "https://example.org/bea-b",
+      "name": "Bea B",
+      "type": "Person",
+      "affiliation": {
+        "id": "https://ror.org/04xfq0f34",
+        "type": "Organization",
+        "name": "RWTH Aachen"
+      }
+    }
+  ],
+  "contributor": [
+    {
+      "name": "Caro C",
+      "type": "Person",
+      "affiliation": {
+        "id": "resource:this-is-a-uri",
+        "type": "Organization",
+        "name": "TH Uni"
+      }
+    }
+  ],
+  "description": "Eine OER",
+  "about": [
+    {
+      "id": "https://w3id.org/kim/hochschulfaechersystematik/n059"
+    }
+  ],
+  "license": {
+    "id": "https://creativecommons.org/publicdomain/zero/1.0/"
+  },
+  "dateCreated": "2019-07-03",
+  "inLanguage": [
+    "fr"
+  ],
+  "publisher": [
+    {
+      "type": "Organization",
+      "name": "Tutory",
+      "id": "https://www.tutory.de"
+    }
+  ],
+  "audience": [
+    {
+      "id": "http://purl.org/dcx/lrmi-vocabs/educationalAudienceRole/student"
+    }
+  ]
+}

--- a/draft/examples/valid/funder.json
+++ b/draft/examples/valid/funder.json
@@ -1,0 +1,21 @@
+{
+  "@context": [
+      "https://w3id.org/kim/amb/context.jsonld",
+      {
+          "@language": "de"
+      }
+  ],
+  "id": "https://example.org/course",
+  "name": "Beispielkurs",
+  "type": [
+      "LearningResource",
+      "Course"
+  ],
+  "funder": [
+    {
+        "type": "FundingScheme",
+        "id": "https://example.org/foerderprogramm",
+        "name": "Förderprogramm A"
+    }
+  ]
+}

--- a/draft/index.html
+++ b/draft/index.html
@@ -606,6 +606,26 @@ Die Organisation oder Person, die für die Veöffentlichung der Ressource verant
 </dl>
 
 </section>
+
+<section data-dfn-for="funder">
+
+### <dfn>funder</dfn>
+
+Angabe, welche Person, Organisation oder welches Förderprogramm an der (finanziellen) Förderung der Ressource beteiligt ist.
+
+<dl>
+<dt>Pflichtfeld</dt>
+<dd>ja</dd>
+<dt>Typ</dd>
+<dd>`array[object]`</dd>
+<dt>Elemente</dt>
+<dd>JSON-Objekt mit Properties `type` und `name`</dd>
+<dt>Validierung</dt>
+<dd><a href="https://w3id.org/kim/amb/draft/schemas/funder.json">JSON Schema</a></dd>
+</dl>
+
+</section>
+
 <!-- end provenance -->
 </section>
 
@@ -660,25 +680,6 @@ Klärung, ob für den Zugang zu Ressource eine Registrierung und Login erfordert
 <dd>JSON-Object mit `id`-Wert aus <a href="https://w3id.org/kim/conditionsOfAccess/">Zugangsbedingungen-Vokabular</a></dd>
 <dt>Validierung</dt>
 <dd><a href="https://w3id.org/kim/amb/draft/schemas/conditionsOfAccess.json">JSON Schema</a></dd>
-</dl>
-
-</section>
-
-<section data-dfn-for="funder">
-
-### <dfn>funder</dfn>
-
-Angabe, welche Person, Organisation oder welches Förderprogramm an der (finanziellen) Förderung der Ressource beteiligt ist.
-
-<dl>
-<dt>Pflichtfeld</dt>
-<dd>ja</dd>
-<dt>Typ</dd>
-<dd>`array[object]`</dd>
-<dt>Elemente</dt>
-<dd>JSON-Objekt mit Properties `type` und `name`</dd>
-<dt>Validierung</dt>
-<dd><a href="https://w3id.org/kim/amb/draft/schemas/funder.json">JSON Schema</a></dd>
 </dl>
 
 </section>

--- a/draft/index.html
+++ b/draft/index.html
@@ -664,6 +664,25 @@ Klärung, ob für den Zugang zu Ressource eine Registrierung und Login erfordert
 
 </section>
 
+<section data-dfn-for="funder">
+
+### <dfn>funder</dfn>
+
+Angabe, welche Person, Organisation oder welches Förderprogramm an der (finanziellen) Förderung der Ressource beteiligt ist.
+
+<dl>
+<dt>Pflichtfeld</dt>
+<dd>ja</dd>
+<dt>Typ</dd>
+<dd>`array[object]`</dd>
+<dt>Elemente</dt>
+<dd>JSON-Objekt mit Properties `type` und `name`</dd>
+<dt>Validierung</dt>
+<dd><a href="https://w3id.org/kim/amb/draft/schemas/funder.json">JSON Schema</a></dd>
+</dl>
+
+</section>
+
 <!-- end rights -->
 </section>
 

--- a/draft/index.html
+++ b/draft/index.html
@@ -677,7 +677,7 @@ Klärung, ob für den Zugang zu Ressource eine Registrierung und Login erfordert
 <dt>Pflichtfeld</dt>
 <dd>nein</dd>
 <dt>Typ</dt>
-<dd>JSON-Object mit `id`-Wert aus <a href="https://w3id.org/kim/conditionsOfAccess/">Zugangsbedingungen-Vokabular</a></dd>
+<dd>JSON-Objekt mit `id`-Wert aus <a href="https://w3id.org/kim/conditionsOfAccess/">Zugangsbedingungen-Vokabular</a></dd>
 <dt>Validierung</dt>
 <dd><a href="https://w3id.org/kim/amb/draft/schemas/conditionsOfAccess.json">JSON Schema</a></dd>
 </dl>
@@ -702,7 +702,7 @@ Art des Lernmittels. MUSS ein oder mehrere JSON-Objekte enthalten, die eine Prop
 <dt>Typ</dt>
 <dd>`array[object]`</dd>
 <dt>Elemente</dt>
-<dd>JSON-Object mit `id`-Wert aus [[HCRT]] oder [[OEHRT]]</dd>
+<dd>JSON-Objekt mit `id`-Wert aus [[HCRT]] oder [[OEHRT]]</dd>
 <dt>Validierung</dt>
 <dd><a href="https://w3id.org/kim/amb/draft/schemas/learningResourceType.json">JSON Schema</a></dd>
 </dl>
@@ -804,7 +804,7 @@ Die Property `id` MUSS einem URI aus den [[Bildungsstufen]] entsprechen.
 <dt>Typ</dt>
 <dd>`array[object]`</dd>
 <dt>Elemente</dt>
-<dd>JSON-Object mit `id`-Wert aus [[Bildungsstufen]] der DINI-AG-KIM. </a></dd>
+<dd>JSON-Objekt mit `id`-Wert aus [[Bildungsstufen]] der DINI-AG-KIM. </a></dd>
 <dt>Validierung</dt>
 <dd><a href="https://w3id.org/kim/amb/draft/schemas/educationalLevel.json">JSON Schema</a></dd>
 </dl>
@@ -824,7 +824,7 @@ Kennzeichnet die vorherrschende Lehr-/Lernform der Ressource und gibt an, ob Leh
 <dt>Pflichtfeld</dt>
 <dd>nein</dd>
 <dt>Typ</dt>
-<dd>JSON-Object mit `id`-Wert aus dem [[Lehr-/Lernform]]-Vokabular</a></dd>
+<dd>JSON-Objekt mit `id`-Wert aus dem [[Lehr-/Lernform]]-Vokabular</a></dd>
 <dt>Validierung</dt>
 <dd><a href="https://w3id.org/kim/amb/draft/schemas/interactivityType.json">JSON Schema</a></dd>
 </dl>

--- a/draft/schemas/funder.json
+++ b/draft/schemas/funder.json
@@ -1,0 +1,31 @@
+{
+  "$id": "https://w3id.org/kim/amb/draft/schemas/funder.json",
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "Funder",
+  "description": "Financial contributor of the learning resource",
+  "type": "array",
+  "properties": {
+    "type": {
+      "title": "Type",
+      "type": "string",
+      "enum": [
+        "Person",
+        "FundingScheme",
+        "Organization"
+      ]
+    },
+    "id": {
+      "title": "URL",
+      "type": "string",
+      "format": "uri"
+    },
+    "name": {
+      "title": "Name",
+      "type": "string"
+    }
+  },
+  "required": [
+    "type",
+    "name"
+  ]
+}

--- a/draft/schemas/schema.json
+++ b/draft/schemas/schema.json
@@ -97,6 +97,9 @@
     "conditionsOfAccess": {
       "$ref": "https://w3id.org/kim/amb/draft/schemas/conditionsOfAccess.json"
     },
+    "funder": {
+      "$ref": "https://w3id.org/kim/amb/draft/schemas/funder.json"
+    },
     "assesses": {
       "$ref": "https://w3id.org/kim/amb/draft/schemas/assesses.json"
     },


### PR DESCRIPTION
Resolves issue #102 to add _funder_ as a new field in section 'Kosten und Rechte', alternative suggestion could be the section 'Entstehung' where publisher, contributor and creator are located? 

Notable changes to [original suggestion](https://github.com/dini-ag-kim/amb/issues/102#issue-1005492167) by @acka47:
- array of objects instead of object
- required "type" & "name" instead of "type" and "id" 
(comparable to schemas of current properties _creator_, _contributor_, _publisher_)

TBD
Some could say that funder is a financial contributor, so technically it could be listed in field _contributor_ with the pretty general description "Sonstige Beitragende zu der Ressource". If we still want _funder_ to be included as separate field (comparable to [schema.org:funder](https://schema.org/funder)), one could think about changing description of contributor to "Sonstige inhaltlich Beitragende zu der Ressource"

Following the [schema.org discussion of contributor roles](https://github.com/schemaorg/schemaorg/issues/384) with [example roles of contribution](https://groups.niso.org/higherlogic/ws/public/download/26466/ANSI-NISO-Z39.104-2022.pdf) the general understanding seems to be distinct enough to integrate _funder_ as a separate field.
