### PR TITLE
Optionale Properties als Pflichtfelder markiert

### DIFF
--- a/draft/index.html
+++ b/draft/index.html
@@ -605,7 +605,7 @@ Die Organisation oder Person, die für die Veröffentlichung der Bildungsressour
 
 <dl>
 <dt>Pflichtfeld</dt>
-<dd>ja</dd>
+<dd>nein</dd>
 <dt>Typ</dt>
 <dd>`array[object]`</dd>
 <dt>Elemente</dt>
@@ -624,7 +624,7 @@ Angabe, welche Person, Organisation oder welches Förderprogramm an der (finanzi
 
 <dl>
 <dt>Pflichtfeld</dt>
-<dd>ja</dd>
+<dd>nein</dd>
 <dt>Typ</dt>
 <dd>`array[object]`</dd>
 <dt>Elemente</dt>
@@ -707,7 +707,7 @@ Art des Lernmittels.
 
 <dl>
 <dt>Pflichtfeld</dt>
-<dd>ja</dd>
+<dd>nein</dd>
 <dt>Typ</dt>
 <dd>`array[object]`</dd>
 <dt>Elemente</dt>


### PR DESCRIPTION
Laut schema.json sind die Felder "publisher", "funder" und "learningResourceType" nicht required. In index.html wurden sie aber als Pflichtfelder beschrieben.