### PR TITLE
Fix learningResourceType regex pattern

### DIFF
--- a/draft/examples/invalid/learningResourceType-wihtout-any-valid-id.json
+++ b/draft/examples/invalid/learningResourceType-wihtout-any-valid-id.json
@@ -11,6 +11,9 @@
   "learningResourceType": [
     {
       "id": "http://purl.org/dcx/lrmi-vocabs/learningResourceType/course"
+    },
+    {
+      "id": "xxxhttp://w3id.org/openeduhub/vocabs/new_lrt/588efe4f-976f-48eb-84aa-8bcb45679f85"
     }
   ]
 }

--- a/draft/schemas/learningResourceType.json
+++ b/draft/schemas/learningResourceType.json
@@ -29,7 +29,7 @@
       "id": {
         "type": "string",
         "format": "uri",
-        "pattern": "(^https://w3id.org/kim/hcrt/.*|http://w3id.org/openeduhub/vocabs/new_lrt/.*)"
+        "pattern": "^(https://w3id.org/kim/hcrt/.*|http://w3id.org/openeduhub/vocabs/new_lrt/.*)"
       }
     },
     "required": ["id"]


### PR DESCRIPTION
Das Pattern für learningResourceType sollte prüfen, ob das "id"-Feld mit den korrekten Werten für hcrt und openeduhub *beginnt*. Das tut das Pattern bisher nur für hcrt.

Fixes #257 