### PR TITLE
datenraum-oss-Repo verlinken

### DIFF
--- a/implementations.md
+++ b/implementations.md
@@ -10,7 +10,7 @@ Falls Du weitere Akteure kennst oder hier selbst gelistet werden möchtest, meld
 - [HessenHub](https://www.hessenhub.de/)
     - Bereitstellung der eigenen Daten nach AMB
 - [MeinBildungsraum](https://www.meinbildungsraum.de/)
-    - AMB wird zur Lieferung von Daten an den gemeinsamen Datenraum empfohlen
+    - AMB wird zur Lieferung von Daten an den gemeinsamen Datenraum empfohlen und wird offenbar als Internformat genutzt, siehe das [datenraum-oss](https://gitlab.opencode.de/mbr/datenraum/datenraum-oss)-Repo
 - [Open Educational Resource Search Index (OERSI)](https://oersi.org)
     - Empfiehlt AMB zur Bereitstellung der Daten
     - Liefert AMB für bereitgestellte Datensätze


### PR DESCRIPTION
Ich bin da neulich drauf gestoßen. AMB scheint dort als internes Format benutz zu werden, siehe https://gitlab.opencode.de/mbr/datenraum/datenraum-oss/-/blob/main/documentation/architecture/index.adoc#user-content-6-2-data-staging, wo es heißt:

> The data staging serves as the exclusive entry point for introducing new content such as learning opportunities from non-editor users into the _Data Space_.
> Its core responsibilities include:
> 
> - Managing diverse metadata standards in JSON and XML forms
> - Validating input data
> - Transforming metadata from the source into the AMB format