### PR TITLE
Fix date test #292

### DIFF
--- a/draft/examples/valid/dateTime.json
+++ b/draft/examples/valid/dateTime.json
@@ -24,7 +24,7 @@
   "license": {
     "id": "https://creativecommons.org/publicdomain/zero/1.0/"
   },
-  "dateCreated": "2019-07-03T13:13:13",
+  "dateCreated": "2019-07-03T13:13:13Z",
   "dateModified": "2022-03-26T08:35:37Z",
   "inLanguage": ["fr"],
   "publisher": [


### PR DESCRIPTION
Wenn man `bash test.sh` ausführt, knallen die Test im Gegensatz zu `npm run tests` durch die Anpassung im Test, validiert auch das dateTime Beispiel bei `bash test.sh`