### PR TITLE
Update schema version to 2020-12 #294

### DIFF
--- a/20231019/schemas/about.json
+++ b/20231019/schemas/about.json
@@ -1,6 +1,6 @@
 {
   "$id": "https://w3id.org/kim/amb/20231019/schemas/about.json",
-  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
   "title": "Subject",
   "description": "The subject of the learning resource, taken from Destatis classification or OpenEduHub-Fächersystematik",
   "type": "array",

--- a/20231019/schemas/affiliation.json
+++ b/20231019/schemas/affiliation.json
@@ -1,6 +1,6 @@
 {
   "$id": "https://w3id.org/kim/amb/20231019/schemas/affiliation.json",
-  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
   "title": "Affiliation",
   "description": "The organization a creator or contributor was affiliated with in the context of the creation of the resource",
   "type": "object",

--- a/20231019/schemas/assesses.json
+++ b/20231019/schemas/assesses.json
@@ -1,6 +1,6 @@
 {
   "$id": "https://w3id.org/kim/amb/20231019/schemas/assesses.json",
-  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
   "title": "Assesses",
   "description": "The item being described is intended to assess the competency or learning outcome defined by the referenced term.",
   "type": "array",

--- a/20231019/schemas/audience.json
+++ b/20231019/schemas/audience.json
@@ -1,6 +1,6 @@
 {
   "$id": "https://w3id.org/kim/amb/20231019/schemas/audience.json",
-  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
   "title": "Intended Audience",
   "description": "The audience the educational resource is intended for.",
   "type": "array",

--- a/20231019/schemas/caption.json
+++ b/20231019/schemas/caption.json
@@ -1,6 +1,6 @@
 {
   "$id": "https://w3id.org/kim/amb/20231019/schemas/caption.json",
-  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
   "title": "Caption",
   "description": "The caption/subtitle file for an audio/video resource",
   "type": "array",

--- a/20231019/schemas/competencyRequired.json
+++ b/20231019/schemas/competencyRequired.json
@@ -1,6 +1,6 @@
 {
   "$id": "https://w3id.org/kim/amb/20231019/schemas/competencyRequired.json",
-  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
   "title": "Competency Required",
   "description": "Knowledge, skill, ability or personal attribute that must be demonstrated by a person or other entity in order to do something such as earn an Educational Occupational Credential or understand a LearningResource.",
   "type": "array",

--- a/20231019/schemas/conditionsOfAccess.json
+++ b/20231019/schemas/conditionsOfAccess.json
@@ -1,6 +1,6 @@
 {
   "$id": "https://w3id.org/kim/amb/20231019/schemas/conditionsOfAccess.json",
-  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
   "title": "conditionsOfAccess",
   "description": "Description if login is needed to use the source.",
   "type": "object",

--- a/20231019/schemas/context-schema.json
+++ b/20231019/schemas/context-schema.json
@@ -1,6 +1,6 @@
 {
   "$id": "https://w3id.org/kim/amb/20231019/schemas/context-schema.json",
-  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
   "title": "JSON-LD Context",
   "description": "The JSON-LD context for the structured resource descriptions",
   "type": "array",

--- a/20231019/schemas/contributor.json
+++ b/20231019/schemas/contributor.json
@@ -1,6 +1,6 @@
 {
   "$id": "https://w3id.org/kim/amb/20231019/schemas/contributor.json",
-  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
   "title": "Contributor",
   "description": "Contributor(s) to the creation of the learning resource",
   "type": "array",

--- a/20231019/schemas/creator.json
+++ b/20231019/schemas/creator.json
@@ -1,6 +1,6 @@
 {
   "$id": "https://w3id.org/kim/amb/20231019/schemas/creator.json",
-  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
   "title": "Creator",
   "description": "The creator(s) of the learning resource",
   "type": "array",

--- a/20231019/schemas/dateCreated.json
+++ b/20231019/schemas/dateCreated.json
@@ -1,6 +1,6 @@
 {
   "$id": "https://w3id.org/kim/amb/20231019/schemas/dateCreated.json",
-  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
   "title": "Creation Date",
   "description": "The creation date in ISO 8601 format: YYYY-MM-DD or CCYY-MM-DDThh:mm:ss[Z|(+|-)hh:mm]",
   "$ref": "https://w3id.org/kim/amb/20231019/schemas/iso8601date.json"

--- a/20231019/schemas/dateModified.json
+++ b/20231019/schemas/dateModified.json
@@ -1,6 +1,6 @@
 {
   "$id": "https://w3id.org/kim/amb/20231019/schemas/dateModified.json",
-  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
   "title": "Modification Date",
   "description": "The modification date in ISO 8601 format: YYYY-MM-DD or CCYY-MM-DDThh:mm:ss[Z|(+|-)hh:mm]",
   "$ref": "https://w3id.org/kim/amb/20231019/schemas/iso8601date.json"

--- a/20231019/schemas/datePublished.json
+++ b/20231019/schemas/datePublished.json
@@ -1,6 +1,6 @@
 {
   "$id": "https://w3id.org/kim/amb/20231019/schemas/datePublished.json",
-  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
   "title": "Publication Date",
   "description": "The publication date in ISO 8601 format: YYYY-MM-DD or CCYY-MM-DDThh:mm:ss[Z|(+|-)hh:mm]",
   "$ref": "https://w3id.org/kim/amb/20231019/schemas/iso8601date.json"

--- a/20231019/schemas/description.json
+++ b/20231019/schemas/description.json
@@ -1,6 +1,6 @@
 {
   "$id": "https://w3id.org/kim/amb/20231019/schemas/description.json",
-  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
   "title": "Description",
   "description": "A description of the learning resource",
   "type": "string"

--- a/20231019/schemas/duration.json
+++ b/20231019/schemas/duration.json
@@ -1,6 +1,6 @@
 {
   "$id": "https://w3id.org/kim/amb/20231019/schemas/duration.json",
-  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
   "title": "Duration",
   "description": "The duration of an audio/video resource (the time it takes to play the audio/video resource) in ISO 8601 duration format: P[n]Y[n]M[n]DT[n]H[n]M[n]S",
   "type": "string",

--- a/20231019/schemas/educationalLevel.json
+++ b/20231019/schemas/educationalLevel.json
@@ -1,6 +1,6 @@
 {
   "$id": "https://w3id.org/kim/amb/20231019/schemas/educationalLevel.json",
-  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
   "title": "Educational context",
   "description": "The level in terms of progression through an educational context for which the learning resource is designated.",
   "type": "array",

--- a/20231019/schemas/encoding.json
+++ b/20231019/schemas/encoding.json
@@ -1,6 +1,6 @@
 {
   "$id": "https://w3id.org/kim/amb/20231019/schemas/encoding.json",
-  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
   "title": "Encoding",
   "description": "A media object that encodes this learning resource",
   "type": "array",

--- a/20231019/schemas/funder.json
+++ b/20231019/schemas/funder.json
@@ -1,6 +1,6 @@
 {
   "$id": "https://w3id.org/kim/amb/20231019/schemas/funder.json",
-  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
   "title": "Funder",
   "description": "Financial contributor of the learning resource",
   "type": "array",

--- a/20231019/schemas/hasPart.json
+++ b/20231019/schemas/hasPart.json
@@ -1,6 +1,6 @@
 {
   "$id": "https://w3id.org/kim/amb/20231019/schemas/hasPart.json",
-  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
   "title": "Has part",
   "description": "Resources that are part of the described learning resource",
   "type": "array",

--- a/20231019/schemas/id.json
+++ b/20231019/schemas/id.json
@@ -1,6 +1,6 @@
 {
   "$id": "https://w3id.org/kim/amb/20231019/schemas/id.json",
-  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
   "title": "URL",
   "description": "The URL/URI of the resource",
   "type": "string",

--- a/20231019/schemas/image.json
+++ b/20231019/schemas/image.json
@@ -1,6 +1,6 @@
 {
   "$id": "https://w3id.org/kim/amb/20231019/schemas/image.json",
-  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
   "title": "Image",
   "type": "string",
   "format": "uri"

--- a/20231019/schemas/inLanguage.json
+++ b/20231019/schemas/inLanguage.json
@@ -1,6 +1,6 @@
 {
   "$id": "https://w3id.org/kim/amb/20231019/schemas/inLanguage.json",
-  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
   "title": "Language",
   "description": "The language of the learning resource",
   "type": "array",

--- a/20231019/schemas/interactivityType.json
+++ b/20231019/schemas/interactivityType.json
@@ -1,6 +1,6 @@
 {
   "$id": "https://w3id.org/kim/amb/20231019/schemas/interactivityType.json",
-  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
   "title": "interactivityType",
   "description": "A concept scheme that defines the predominate interact mode of the learning resource being described.",
   "type": "object",

--- a/20231019/schemas/isAccessibleForFree.json
+++ b/20231019/schemas/isAccessibleForFree.json
@@ -1,6 +1,6 @@
 {
   "$id": "https://w3id.org/kim/amb/20231019/schemas/isAccessibleForFree.json",
-  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
   "title": "Status of free accessibility",
   "description": "States if a ressource is free to access and to use. This also can be a ressource without an open license",
   "type": "boolean"

--- a/20231019/schemas/isBasedOn.json
+++ b/20231019/schemas/isBasedOn.json
@@ -1,6 +1,6 @@
 {
   "$id": "https://w3id.org/kim/amb/20231019/schemas/isBasedOn.json",
-  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
   "title": "Based on",
   "description": "Resources the described learning resources derived from.",
   "type": "array",

--- a/20231019/schemas/isPartOf.json
+++ b/20231019/schemas/isPartOf.json
@@ -1,6 +1,6 @@
 {
   "$id": "https://w3id.org/kim/amb/20231019/schemas/isPartOf.json",
-  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
   "title": "Is part of",
   "description": "Resources the described learning resource is part of.",
   "type": "array",

--- a/20231019/schemas/iso8601date.json
+++ b/20231019/schemas/iso8601date.json
@@ -1,6 +1,6 @@
 {
   "$id": "https://w3id.org/kim/amb/20231019/schemas/iso8601date.json",
-  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
   "title": "ISO 8601 Date",
   "description": "A date in ISO 8601 format.",
   "oneOf": [

--- a/20231019/schemas/keywords.json
+++ b/20231019/schemas/keywords.json
@@ -1,6 +1,6 @@
 {
   "$id": "https://w3id.org/kim/amb/20231019/schemas/keywords.json",
-  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
   "title": "Keywords",
   "description": "Keywords or tags used to describe this content",
   "type": "array",

--- a/20231019/schemas/language.json
+++ b/20231019/schemas/language.json
@@ -1,6 +1,6 @@
 {
   "$id": "https://w3id.org/kim/amb/20231019/schemas/language.json",
-  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
   "title": "Language code",
   "description": "An enumeration of ISO 639-1.conformant two-digit language codes.",
   "type": "string",

--- a/20231019/schemas/learningResourceType.json
+++ b/20231019/schemas/learningResourceType.json
@@ -1,6 +1,6 @@
 {
   "$id": "https://w3id.org/kim/amb/20231019/schemas/learningResourceType.json",
-  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
   "title": "Learning Resource Type",
   "description": "The learning resource type of the resource, taken from the controlled HCRT list or the OpenEduHub vocabulary for learningResourceType",
   "type": "array",

--- a/20231019/schemas/license.json
+++ b/20231019/schemas/license.json
@@ -1,6 +1,6 @@
 {
   "$id": "https://w3id.org/kim/amb/20231019/schemas/license.json",
-  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
   "title": "License",
   "description": "An object that links to an open source license. Public Domain, Creative Commons, GNU, Apache, MIT and BSD are allowed",
   "type": "object",

--- a/20231019/schemas/localizedString.json
+++ b/20231019/schemas/localizedString.json
@@ -1,6 +1,6 @@
 {
   "$id": "https://w3id.org/kim/amb/20231019/schemas/localizedString.json",
-  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
   "title": "Localized String",
   "description": "A language-tagged string using JSON-LD \"language maps\", see https://www.w3.org/TR/json-ld/#language-maps",
   "type": "object",

--- a/20231019/schemas/mainEntityOfPage.json
+++ b/20231019/schemas/mainEntityOfPage.json
@@ -1,6 +1,6 @@
 {
   "$id": "https://w3id.org/kim/amb/20231019/schemas/mainEntityOfPage.json",
-  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
   "title": "Metadata/Structured descriptions",
   "description": "This object contains metametadata, i.e. information about the structured description(s) of the OER and its source(s).",
   "type": "array",

--- a/20231019/schemas/name.json
+++ b/20231019/schemas/name.json
@@ -1,6 +1,6 @@
 {
   "$id": "https://w3id.org/kim/amb/20231019/schemas/name.json",
-  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
   "title": "Title",
   "description": "The title of the learning resource",
   "type": "string"

--- a/20231019/schemas/provider.json
+++ b/20231019/schemas/provider.json
@@ -1,6 +1,6 @@
 {
   "$id": "https://w3id.org/kim/amb/20231019/schemas/provider.json",
-  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
   "title": "Provider",
   "description": "Quelle, von der eine Bildungsressource oder deren Metadaten zur Verfügung gestellt werden.",
   "type": "object",

--- a/20231019/schemas/publisher.json
+++ b/20231019/schemas/publisher.json
@@ -1,6 +1,6 @@
 {
   "$id": "https://w3id.org/kim/amb/20231019/schemas/publisher.json",
-  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
   "title": "Publisher",
   "description": "The publisher of the educational resource",
   "type": "array",

--- a/20231019/schemas/schema.json
+++ b/20231019/schemas/schema.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "https://w3id.org/kim/amb/20231019/schemas/schema.json",
   "title": "OER",
   "description": "This is a generic JSON schema for describing an Open Educational Resource with schema.org",

--- a/20231019/schemas/teaches.json
+++ b/20231019/schemas/teaches.json
@@ -1,6 +1,6 @@
 {
   "$id": "https://w3id.org/kim/amb/20231019/schemas/teaches.json",
-  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
   "title": "Teaches",
   "description": "The item being described is intended to help a person learn the competency or learning outcome defined by the referenced term.",
   "type": "array",

--- a/20231019/schemas/trailer.json
+++ b/20231019/schemas/trailer.json
@@ -1,6 +1,6 @@
 {
   "$id": "https://w3id.org/kim/amb/20231019/schemas/trailer.json",
-  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
   "title": "Trailer",
   "description": "Ein Trailer/Video-Teaser zu einer Ressource",
   "type": "object",

--- a/20231019/schemas/type.json
+++ b/20231019/schemas/type.json
@@ -1,6 +1,6 @@
 {
   "$id": "https://w3id.org/kim/amb/20231019/schemas/type.json",
-  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
   "title": "Type",
   "description": "The type (rdf:type / @type) of the learning resource, taken from sub-classes of sdo:CreativeWork.",
   "type": "array",

--- a/draft/schemas/about.json
+++ b/draft/schemas/about.json
@@ -1,6 +1,6 @@
 {
   "$id": "https://w3id.org/kim/amb/draft/schemas/about.json",
-  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
   "title": "Subject",
   "description": "The subject of the learning resource, taken from Destatis classification or OpenEduHub-Fächersystematik",
   "type": "array",

--- a/draft/schemas/affiliation.json
+++ b/draft/schemas/affiliation.json
@@ -1,6 +1,6 @@
 {
   "$id": "https://w3id.org/kim/amb/draft/schemas/affiliation.json",
-  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
   "title": "Affiliation",
   "description": "The organization a creator or contributor was affiliated with in the context of the creation of the resource",
   "type": "object",

--- a/draft/schemas/assesses.json
+++ b/draft/schemas/assesses.json
@@ -1,6 +1,6 @@
 {
   "$id": "https://w3id.org/kim/amb/draft/schemas/assesses.json",
-  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
   "title": "Assesses",
   "description": "The item being described is intended to assess the competency or learning outcome defined by the referenced term.",
   "type": "array",

--- a/draft/schemas/audience.json
+++ b/draft/schemas/audience.json
@@ -1,6 +1,6 @@
 {
   "$id": "https://w3id.org/kim/amb/draft/schemas/audience.json",
-  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
   "title": "Intended Audience",
   "description": "The audience the educational resource is intended for.",
   "type": "array",

--- a/draft/schemas/caption.json
+++ b/draft/schemas/caption.json
@@ -1,6 +1,6 @@
 {
   "$id": "https://w3id.org/kim/amb/draft/schemas/caption.json",
-  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
   "title": "Caption",
   "description": "The caption/subtitle file for an audio/video resource",
   "type": "array",

--- a/draft/schemas/competencyRequired.json
+++ b/draft/schemas/competencyRequired.json
@@ -1,6 +1,6 @@
 {
   "$id": "https://w3id.org/kim/amb/draft/schemas/competencyRequired.json",
-  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
   "title": "Competency Required",
   "description": "Knowledge, skill, ability or personal attribute that must be demonstrated by a person or other entity in order to do something such as earn an Educational Occupational Credential or understand a LearningResource.",
   "type": "array",

--- a/draft/schemas/conditionsOfAccess.json
+++ b/draft/schemas/conditionsOfAccess.json
@@ -1,6 +1,6 @@
 {
   "$id": "https://w3id.org/kim/amb/draft/schemas/conditionsOfAccess.json",
-  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
   "title": "conditionsOfAccess",
   "description": "Description if login is needed to use the source.",
   "type": "object",

--- a/draft/schemas/context-schema.json
+++ b/draft/schemas/context-schema.json
@@ -1,6 +1,6 @@
 {
   "$id": "https://w3id.org/kim/amb/draft/schemas/context-schema.json",
-  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
   "title": "JSON-LD Context",
   "description": "The JSON-LD context for the structured resource descriptions",
   "type": "array",

--- a/draft/schemas/contributor.json
+++ b/draft/schemas/contributor.json
@@ -1,6 +1,6 @@
 {
   "$id": "https://w3id.org/kim/amb/draft/schemas/contributor.json",
-  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
   "title": "Contributor",
   "description": "Contributor(s) to the creation of the learning resource",
   "type": "array",

--- a/draft/schemas/creator.json
+++ b/draft/schemas/creator.json
@@ -1,6 +1,6 @@
 {
   "$id": "https://w3id.org/kim/amb/draft/schemas/creator.json",
-  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
   "title": "Creator",
   "description": "The creator(s) of the learning resource",
   "type": "array",

--- a/draft/schemas/dateCreated.json
+++ b/draft/schemas/dateCreated.json
@@ -1,6 +1,6 @@
 {
   "$id": "https://w3id.org/kim/amb/draft/schemas/dateCreated.json",
-  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
   "title": "Creation Date",
   "description": "The creation date in ISO 8601 format: YYYY-MM-DD or CCYY-MM-DDThh:mm:ss[Z|(+|-)hh:mm]",
   "$ref": "https://w3id.org/kim/amb/draft/schemas/iso8601date.json"

--- a/draft/schemas/dateModified.json
+++ b/draft/schemas/dateModified.json
@@ -1,6 +1,6 @@
 {
   "$id": "https://w3id.org/kim/amb/draft/schemas/dateModified.json",
-  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
   "title": "Modification Date",
   "description": "The modification date in ISO 8601 format: YYYY-MM-DD or CCYY-MM-DDThh:mm:ss[Z|(+|-)hh:mm]",
   "$ref": "https://w3id.org/kim/amb/draft/schemas/iso8601date.json"

--- a/draft/schemas/datePublished.json
+++ b/draft/schemas/datePublished.json
@@ -1,6 +1,6 @@
 {
   "$id": "https://w3id.org/kim/amb/draft/schemas/datePublished.json",
-  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
   "title": "Publication Date",
   "description": "The publication date in ISO 8601 format: YYYY-MM-DD or CCYY-MM-DDThh:mm:ss[Z|(+|-)hh:mm]",
   "$ref": "https://w3id.org/kim/amb/draft/schemas/iso8601date.json"

--- a/draft/schemas/description.json
+++ b/draft/schemas/description.json
@@ -1,6 +1,6 @@
 {
   "$id": "https://w3id.org/kim/amb/draft/schemas/description.json",
-  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
   "title": "Description",
   "description": "A description of the learning resource",
   "type": "string"

--- a/draft/schemas/duration.json
+++ b/draft/schemas/duration.json
@@ -1,6 +1,6 @@
 {
   "$id": "https://w3id.org/kim/amb/draft/schemas/duration.json",
-  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
   "title": "Duration",
   "description": "The duration of an audio/video resource (the time it takes to play the audio/video resource) in ISO 8601 duration format: P[n]Y[n]M[n]DT[n]H[n]M[n]S",
   "type": "string",

--- a/draft/schemas/educationalLevel.json
+++ b/draft/schemas/educationalLevel.json
@@ -1,6 +1,6 @@
 {
   "$id": "https://w3id.org/kim/amb/draft/schemas/educationalLevel.json",
-  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
   "title": "Educational context",
   "description": "The level in terms of progression through an educational context for which the learning resource is designated.",
   "type": "array",

--- a/draft/schemas/encoding.json
+++ b/draft/schemas/encoding.json
@@ -1,6 +1,6 @@
 {
   "$id": "https://w3id.org/kim/amb/draft/schemas/encoding.json",
-  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
   "title": "Encoding",
   "description": "A media object that encodes this learning resource",
   "type": "array",

--- a/draft/schemas/funder.json
+++ b/draft/schemas/funder.json
@@ -1,6 +1,6 @@
 {
   "$id": "https://w3id.org/kim/amb/draft/schemas/funder.json",
-  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
   "title": "Funder",
   "description": "Financial contributor of the learning resource",
   "type": "array",

--- a/draft/schemas/hasPart.json
+++ b/draft/schemas/hasPart.json
@@ -1,6 +1,6 @@
 {
   "$id": "https://w3id.org/kim/amb/draft/schemas/hasPart.json",
-  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
   "title": "Has part",
   "description": "Resources that are part of the described learning resource",
   "type": "array",

--- a/draft/schemas/id.json
+++ b/draft/schemas/id.json
@@ -1,6 +1,6 @@
 {
   "$id": "https://w3id.org/kim/amb/draft/schemas/id.json",
-  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
   "title": "URL",
   "description": "The URL/URI of the resource",
   "type": "string",

--- a/draft/schemas/image.json
+++ b/draft/schemas/image.json
@@ -1,6 +1,6 @@
 {
   "$id": "https://w3id.org/kim/amb/draft/schemas/image.json",
-  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
   "title": "Image",
   "type": "string",
   "format": "uri"

--- a/draft/schemas/inLanguage.json
+++ b/draft/schemas/inLanguage.json
@@ -1,6 +1,6 @@
 {
   "$id": "https://w3id.org/kim/amb/draft/schemas/inLanguage.json",
-  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
   "title": "Language",
   "description": "The language of the learning resource",
   "type": "array",

--- a/draft/schemas/interactivityType.json
+++ b/draft/schemas/interactivityType.json
@@ -1,6 +1,6 @@
 {
   "$id": "https://w3id.org/kim/amb/draft/schemas/interactivityType.json",
-  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
   "title": "interactivityType",
   "description": "A concept scheme that defines the predominate interact mode of the learning resource being described.",
   "type": "object",

--- a/draft/schemas/isAccessibleForFree.json
+++ b/draft/schemas/isAccessibleForFree.json
@@ -1,6 +1,6 @@
 {
   "$id": "https://w3id.org/kim/amb/draft/schemas/isAccessibleForFree.json",
-  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
   "title": "Status of free accessibility",
   "description": "States if a ressource is free to access and to use. This also can be a ressource without an open license",
   "type": "boolean"

--- a/draft/schemas/isBasedOn.json
+++ b/draft/schemas/isBasedOn.json
@@ -1,6 +1,6 @@
 {
   "$id": "https://w3id.org/kim/amb/draft/schemas/isBasedOn.json",
-  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
   "title": "Based on",
   "description": "Resources the described learning resources derived from.",
   "type": "array",

--- a/draft/schemas/isPartOf.json
+++ b/draft/schemas/isPartOf.json
@@ -1,6 +1,6 @@
 {
   "$id": "https://w3id.org/kim/amb/draft/schemas/isPartOf.json",
-  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
   "title": "Is part of",
   "description": "Resources the described learning resource is part of.",
   "type": "array",

--- a/draft/schemas/iso8601date.json
+++ b/draft/schemas/iso8601date.json
@@ -1,6 +1,6 @@
 {
   "$id": "https://w3id.org/kim/amb/draft/schemas/iso8601date.json",
-  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
   "title": "ISO 8601 Date",
   "description": "A date in ISO 8601 format.",
   "oneOf": [

--- a/draft/schemas/keywords.json
+++ b/draft/schemas/keywords.json
@@ -1,6 +1,6 @@
 {
   "$id": "https://w3id.org/kim/amb/draft/schemas/keywords.json",
-  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
   "title": "Keywords",
   "description": "Keywords or tags used to describe this content",
   "type": "array",

--- a/draft/schemas/language.json
+++ b/draft/schemas/language.json
@@ -1,6 +1,6 @@
 {
   "$id": "https://w3id.org/kim/amb/draft/schemas/language.json",
-  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
   "title": "Language code",
   "description": "An enumeration of ISO 639-1.conformant two-digit language codes.",
   "type": "string",

--- a/draft/schemas/learningResourceType.json
+++ b/draft/schemas/learningResourceType.json
@@ -1,6 +1,6 @@
 {
   "$id": "https://w3id.org/kim/amb/draft/schemas/learningResourceType.json",
-  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
   "title": "Learning Resource Type",
   "description": "The learning resource type of the resource, taken from the controlled HCRT list or the OpenEduHub vocabulary for learningResourceType",
   "type": "array",

--- a/draft/schemas/license.json
+++ b/draft/schemas/license.json
@@ -1,6 +1,6 @@
 {
   "$id": "https://w3id.org/kim/amb/draft/schemas/license.json",
-  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
   "title": "License",
   "description": "An object that links to an open source license. Public Domain, Creative Commons, GNU, Apache, MIT and BSD are allowed",
   "type": "object",

--- a/draft/schemas/localizedString.json
+++ b/draft/schemas/localizedString.json
@@ -1,6 +1,6 @@
 {
   "$id": "https://w3id.org/kim/amb/draft/schemas/localizedString.json",
-  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
   "title": "Localized String",
   "description": "A language-tagged string using JSON-LD \"language maps\", see https://www.w3.org/TR/json-ld/#language-maps",
   "type": "object",

--- a/draft/schemas/mainEntityOfPage.json
+++ b/draft/schemas/mainEntityOfPage.json
@@ -1,6 +1,6 @@
 {
   "$id": "https://w3id.org/kim/amb/draft/schemas/mainEntityOfPage.json",
-  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
   "title": "Metadata/Structured descriptions",
   "description": "This object contains metametadata, i.e. information about the structured description(s) of the OER and its source(s).",
   "type": "array",

--- a/draft/schemas/name.json
+++ b/draft/schemas/name.json
@@ -1,6 +1,6 @@
 {
   "$id": "https://w3id.org/kim/amb/draft/schemas/name.json",
-  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
   "title": "Title",
   "description": "The title of the learning resource",
   "type": "string"

--- a/draft/schemas/provider.json
+++ b/draft/schemas/provider.json
@@ -1,6 +1,6 @@
 {
   "$id": "https://w3id.org/kim/amb/draft/schemas/provider.json",
-  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
   "title": "Provider",
   "description": "Quelle, von der eine Bildungsressource oder deren Metadaten zur Verfügung gestellt werden.",
   "type": "object",

--- a/draft/schemas/publisher.json
+++ b/draft/schemas/publisher.json
@@ -1,6 +1,6 @@
 {
   "$id": "https://w3id.org/kim/amb/draft/schemas/publisher.json",
-  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
   "title": "Publisher",
   "description": "The publisher of the educational resource",
   "type": "array",

--- a/draft/schemas/schema.json
+++ b/draft/schemas/schema.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "https://w3id.org/kim/amb/draft/schemas/schema.json",
   "title": "OER",
   "description": "This is a generic JSON schema for describing an Open Educational Resource with schema.org",

--- a/draft/schemas/teaches.json
+++ b/draft/schemas/teaches.json
@@ -1,6 +1,6 @@
 {
   "$id": "https://w3id.org/kim/amb/draft/schemas/teaches.json",
-  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
   "title": "Teaches",
   "description": "The item being described is intended to help a person learn the competency or learning outcome defined by the referenced term.",
   "type": "array",

--- a/draft/schemas/trailer.json
+++ b/draft/schemas/trailer.json
@@ -1,6 +1,6 @@
 {
   "$id": "https://w3id.org/kim/amb/draft/schemas/trailer.json",
-  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
   "title": "Trailer",
   "description": "Ein Trailer/Video-Teaser zu einer Ressource",
   "type": "object",

--- a/draft/schemas/type.json
+++ b/draft/schemas/type.json
@@ -1,6 +1,6 @@
 {
   "$id": "https://w3id.org/kim/amb/draft/schemas/type.json",
-  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
   "title": "Type",
   "description": "The type (rdf:type / @type) of the learning resource, taken from sub-classes of sdo:CreativeWork.",
   "type": "array",

--- a/test.sh
+++ b/test.sh
@@ -3,7 +3,7 @@
 set -e
 
 run_ajv() {
-  ajv test -s draft/schemas/schema.json -r "draft/schemas/!(schema).json" \
+  ajv test --spec=draft2020  -s draft/schemas/schema.json -r "draft/schemas/!(schema).json" \
     -d "$1" -c ajv-formats $2
 }
 


### PR DESCRIPTION
Dies soll ein Draft des Versionsupdate sein, ajv unterstützt mittlerweile 2020-12 #294

~~Der Commit baut auf dini-ag-kim:292-fixDateTest auf, da dort ein kaputter Test gefixt wird.~~ (Edit: Das wurde zurückgenommen, da es in einem anderen Kontext gelöst wird und unabhänigg von der Aktualisierung der ajv Version ist.)