### PR TITLE
RegEx-Pattern bei license-Schema angepasst

### DIFF
--- a/20231019/schemas/license.json
+++ b/20231019/schemas/license.json
@@ -11,23 +11,23 @@
       "oneOf": [
         {
           "description": "Creative Commons License or Public Domain",
-          "pattern": "^http[s]?://creativecommons.org/(licenses|licences|publicdomain)/.*"
+          "pattern": "^http[s]?://(www.)?creativecommons.org/(licenses|licences|publicdomain)/.*"
         },
         {
           "description": "GNU License",
-          "pattern": "^http[s]?://www.gnu.org/licenses/.*"
+          "pattern": "^http[s]?://(www.)?gnu.org/licenses/.*"
         },
         {
           "description": "Apache License",
-          "pattern": "^http[s]?://www.apache.org/licenses/.*"
+          "pattern": "^http[s]?://(www.)?apache.org/licenses/.*"
         },
         {
           "description": "MIT License",
-          "pattern": "http[s]?://opensource.org/licenses/MIT"
+          "pattern": "^http[s]?://(www.)?opensource.org/licenses?/(mit|MIT)"
         },
         {
           "description": "BSD License",
-          "pattern": "^http[s]?://www.opensource.org/licenses/BSD.*"
+          "pattern": "^http[s]?://(www.)?opensource.org/licenses?/(bsd|BSD).*"
         }
       ]
     }


### PR DESCRIPTION
Ich habe die regulären Ausdrücke für die Pattern nur leicht angepasst, damit mehr Möglichkeiten akzeptabel sind.

Allerdings gibt es verschiedene offene Fragestellungen für mich:
 - Braucht es das Fragezeichen hinter licenses? bei opensource.org, da es ja nur die Variante license gibt; oder bricht dadurch etwas? Im vorgeschlagenen Fix wurde das ergänzt, aber ich sehe nicht so wirklich, was der Sinn davon ist.
 - Muss http[s] in Klammern stehen oder reicht nicht ein https? aus?
 - Sollten die Domainpunkte (zum Beispiel bei .org) nicht escapet werden, da es sich sonst um beliebige Zeichen handeln könnte?